### PR TITLE
Update team.json

### DIFF
--- a/boards/team.json
+++ b/boards/team.json
@@ -9,12 +9,12 @@
             "description": "Issues added to the current sprint"
         },
         {
-            "name": "Review Rework",
-            "description": "Issues that have been reviewed and need rework"
+            "name": "Research",
+            "description": "Issues, which need to be investigated regards their applicability & solutioning"
         },
         {
             "name": "In Progress",
-            "description": "Issues that are in progress"
+            "description": "Issues that are in progress / Rework from reviews"
         },
         {
             "name": "Team Review",


### PR DESCRIPTION
@SchettlerKoehler, @Bene90, @baumeister25 

what do you think about this change? It was helpful to change it in the cobigen team this way, but has been reset by the automatic pipeline configuration. Not sure how it was done in the other teams, but I don't see the need of the rework review column on the board and would rather vote for a research column where we have timeboxed topics to work on for researching options of implementation and applicability before estimation.