### PR TITLE
Remove trailling blank from repo name

### DIFF
--- a/teams/core.asciidoc
+++ b/teams/core.asciidoc
@@ -17,7 +17,7 @@
 * devonfw/hangar
 * devonfw/devon4ng-ngrx-template
 * devonfw/my-thai-star
-* devonfw/devon4net 
+* devonfw/devon4net
 * devonfw/devonfw.github.io
 * devonfw/devonfw-guide
 * devonfw/devon4j


### PR DESCRIPTION
The trailling blank lead to an error when identifying the repo name.